### PR TITLE
Fixes for asset spec support

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -19,14 +19,21 @@ class Environment(Environment):
         return super(Environment, self)._normalize_source_path(spath)
 
     def absurl(self, fragment):
-        if ':' in fragment:
-            request = get_current_request()
-            try:
-                return request.static_url(fragment)
-            except ValueError, e:
-                raise BundleError(e)
+        query = None
+        request = get_current_request()
 
-        return super(Environment, self).absurl(fragment)
+        if self.url_expire != False and '?' in fragment:
+          fragment, query = fragment.rsplit('?', 1)
+
+        if not ':' in fragment:
+          # Get the path to the file if it's not an asset spec
+          fragment = super(Environment, self).abspath(fragment)
+
+        try:
+            fragment = request.static_url(fragment)
+            return query and "%s?%s" % (fragment, query) or fragment
+        except ValueError, e:
+             raise BundleError(e)
 
 
 class IWebAssetsEnvironment(Interface):

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -247,7 +247,8 @@ class TestAssetSpecs(TempDirHelper, unittest2.TestCase):
         bundle = Bundle(asset_spec, output='gen/zung.css')
 
         urls = bundle.urls(self.env)
-        assert urls == ['/static/gen/zung.css']
+        assert urls == ['http://example.com/static/gen/zung.css']
+        urls[0] = urls[0][len(self.request.application_url):]
         assert file(self.tempdir+urls[0]).read() == '* { text-decoration: underline }'
 
     def test_asset_spec_missing_file(self):


### PR DESCRIPTION
With this change, pyramid_webassets adds a static view for the user, mapping the base directory to the base url from the configuration. In this way, `request.static_url` can be used for all files.

Absolute asset specifications will be served if they have their own static views (such as those provided by deform). In my testing, I can specify a bundle with contents like "deform:static/js/jquery-1.7.2.min.js" and the url (http://example.com/static-deform/js/jquery-1.7.2.min.js).

Relative paths are still relative to the base dir, but the new static view ensures that absolute urls can still be generated for these URLs.
