### PR TITLE
Add webassets_env as reified property on request object. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ If you are using Jinja2, you can just do the following configuration (this assum
     jinja2_env.assets_environment = assets_env
  ```
 
+From The Request
+====================
+If you are not using Jinja2, you can still access the environment from the request.
+
+```python
+    jst_urls = request.webassets_env['jst'].urls()
+ ```
+
 Extras
 ====================
 There are a few utility methods you can use:

--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -98,6 +98,11 @@ def get_webassets_env_from_settings(settings, prefix='webassets'):
     return assets_env
 
 
+def get_webassets_env_from_request(request):
+    """ Get the webassets environment in the registry from the request. """
+    return request.registry.queryUtility(IWebAssetsEnvironment)
+
+
 def includeme(config):
     assets_env = get_webassets_env_from_settings(config.registry.settings)
 
@@ -106,4 +111,5 @@ def includeme(config):
     config.add_directive('add_webasset', add_webasset)
     config.add_directive('get_webassets_env', get_webassets_env)
     config.add_static_view(assets_env.url, assets_env.directory)
-
+    config.set_request_property(get_webassets_env_from_request,
+        'webassets_env', reify=True)

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -153,14 +153,17 @@ class TestWebAssets(unittest2.TestCase):
         from pyramid_webassets import includeme
         from pyramid_webassets import add_webasset
         from pyramid_webassets import get_webassets_env
+        from pyramid_webassets import get_webassets_env_from_request
 
         config = Mock()
         add_directive = Mock()
         registerUtility = Mock()
+        set_request_property = Mock()
 
         config.registry = Mock()
         config.registry.registerUtility = registerUtility
         config.add_directive = add_directive
+        config.set_request_property = set_request_property
 
         settings = {
             'webassets.base_url': '/static',
@@ -175,6 +178,23 @@ class TestWebAssets(unittest2.TestCase):
         expected2 = ('get_webassets_env', get_webassets_env)
         assert add_directive.call_args_list[0][0] == expected1
         assert add_directive.call_args_list[1][0] == expected2
+
+        assert set_request_property.call_args_list[0][0] == \
+            (get_webassets_env_from_request, 'webassets_env')
+
+    def test_get_webassets_env_from_request(self):
+        from pyramid_webassets import get_webassets_env_from_request
+        from pyramid_webassets import IWebAssetsEnvironment
+
+        request = Mock()
+        request.registry = Mock()
+        queryUtility = Mock()
+        request.registry.queryUtility = queryUtility
+
+        env = get_webassets_env_from_request(request)
+        queryUtility.assert_called_with(IWebAssetsEnvironment)
+
+        assert env != None
 
 
 class TestAssetSpecs(TempDirHelper, unittest2.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ README = _read(os.path.join(here, 'README.md'))
 CHANGES = _read(os.path.join(here, 'CHANGES.txt'))
 
 #requires = open('requirements.txt').readlines()
-requires = ['pyramid', 'webassets>=0.7.1', 'zope.interface']
+requires = ['pyramid>=1.3', 'webassets>=0.7.1', 'zope.interface']
 
 class PyTest(Command):
     user_options = []


### PR DESCRIPTION
More or less what we talked about.  I tried to keep it consistent with the existing tools.

I was thinking though, should the request property only be set it if the set_request_property method exists on config?  Or better yet should it be configurable?
