### PR TITLE
Adding JST_NAMESPACE option

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -137,6 +137,9 @@ def get_webassets_env_from_settings(settings, prefix='webassets'):
     if 'jst_compiler' in kwargs:
         kwargs['JST_COMPILER'] = kwargs.pop('jst_compiler')
 
+    if 'jst_namespace' in kwargs:
+        kwargs['JST_NAMESPACE'] = kwargs.pop('jst_namespace')
+
     if 'manifest' in kwargs:
         manifest = kwargs['manifest'].lower()
 

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -129,7 +129,8 @@ class TestWebAssets(unittest.TestCase):
             'webassets.debug': 'true',
             'webassets.cache': 'false',
             'webassets.updater': 'always',
-            'webassets.jst_compiler': 'Handlebars.compile'
+            'webassets.jst_compiler': 'Handlebars.compile',
+            'webassets.jst_namespace': 'window.Ember.TEMPLATES'
         }
 
         env = get_webassets_env_from_settings(settings)
@@ -139,6 +140,7 @@ class TestWebAssets(unittest.TestCase):
         assert env.debug == True
         assert isinstance(env.updater, webassets.updater.AlwaysUpdater)
         assert env.config['JST_COMPILER'] == settings['webassets.jst_compiler']
+        assert env.config['JST_NAMESPACE'] == settings['webassets.jst_namespace']
         assert env.cache == None
         assert env.auto_build == True
 


### PR DESCRIPTION
This is handy for merging Handlebar templates into the Ember namespace.
