### PR TITLE
Remove print statement from tests.

### DIFF
--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -293,7 +293,6 @@ class TestAssetSpecs(TempDirHelper, unittest.TestCase):
 
         urls = bundle.urls(self.env)
         path = AssetResolver(None).resolve(asset_spec).abspath()
-        print path
         self.request.static_url.assert_called_with(path)
         assert urls == ['http://example.com/foo/']
 


### PR DESCRIPTION
Removes print statement that was introduces in the tests. print breaks install on python 3.
