### PR TITLE
Add `load_path` to supported options

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -26,7 +26,14 @@ class PyramidResolver(Resolver):
         else:
             return (None, item)
 
+    @property
+    def use_webassets_system_for_sources(self):
+        return bool(self.env.load_path)
+
     def search_for_source(self, item):
+        if self.use_webassets_system_for_sources:
+            return super(PyramidResolver, self).search_for_source(item)
+
         package, filepath = self._split_asset_spec(item)
         if package is None:
             return super(PyramidResolver, self).search_for_source(filepath)
@@ -167,6 +174,9 @@ def get_webassets_env_from_settings(settings, prefix='webassets'):
         kwargs['cache_max_age'] = int(kwargs.pop('cache_max_age'))
     else:
         kwargs['cache_max_age'] = None
+
+    if 'load_path' in kwargs:
+        kwargs['load_path'] = kwargs['load_path'].split()
 
     assets_env = Environment(asset_dir, asset_url, **kwargs)
 

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -451,3 +451,15 @@ class TestAssetSpecs(TempDirHelper, unittest.TestCase):
 
         urls = bundle.urls(self.env)
         assert urls == ['http://static.example.com/zung.css']
+
+    def test_use_load_path_if_defined(self):
+        from pyramid_webassets import get_webassets_env_from_settings
+
+        settings = {
+            'webassets.base_url': '/static',
+            'webassets.base_dir': os.getcwd(),
+            'webassets.load_path': '\n/foo\n/bar'
+        }
+
+        env = get_webassets_env_from_settings(settings)
+        assert env.load_path == ['/foo', '/bar']

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class PyTest(Command):
         raise SystemExit(errno)
 
 setup(name='pyramid_webassets',
-      version='0.7',
+      version='0.8',
       description='pyramid_webassets',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
http://elsdoerfer.name/docs/webassets/environment.html#webassets.env.Environment.load_path

By specifying load_path webassets.base_dir now becomes solely the destination
directory of compressed files. This allows writing compressed assets to a
destination outside of the application directory
