### PR TITLE
Exclude json parsing of manifest value

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -129,7 +129,7 @@ def get_webassets_env_from_settings(settings, prefix='webassets'):
             if isinstance(val, six.string_types):
                 if val.lower() in auto_booly:
                     val = asbool(val)
-                elif val.lower().startswith('json:'):
+                elif val.lower().startswith('json:') and k[cut_prefix:] != 'manifest':
                     val = json.loads(val[5:])
             kwargs[k[cut_prefix:]] = val
 


### PR DESCRIPTION
As of 8d503a8e991888c5c87b256be03fe41ba7ec0248 it seems json manifest support is broken.
eg. `webassets.manifest = json:%(here)s/manifest.json`

http://webassets.readthedocs.org/en/latest/environment.html?highlight=manifest#webassets.env.Environment.manifest

This excludes the manifest value from being parsed as json.
