### PR TITLE
Version source URLs

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -8,6 +8,7 @@ from pyramid.settings       import asbool, truthy
 from pyramid.threadlocal    import get_current_request
 from zope.interface         import Interface
 from webassets              import Bundle
+from webassets.bundle       import has_placeholder
 from webassets.env          import Environment
 from webassets.env          import Resolver
 from webassets.exceptions   import BundleError
@@ -54,16 +55,47 @@ class PyramidResolver(Resolver):
 
     def resolve_source_to_url(self, filepath, item):
         request = get_current_request()
+        env = self.env
 
+        # Copied from webassets 0.8. Reproduced here for backwards
+        # compatibility with the previous webassets release.
+        # This ensures files which do not require building are still served
+        # with proper versioning of URLs.
+        # This can likely be removed once miracle2k/webassets#117 is fixed.
+
+        # Only query the version if we need to for performance
+        version = None
+        if has_placeholder(filepath) or env.url_expire != False:
+            # If auto-build is enabled, we must not use a cached version
+            # value, or we might serve old versions.
+            bundle = Bundle(item, output=filepath)
+            version = bundle.get_version(env, refresh=env.auto_build)
+
+        url = filepath
+        if has_placeholder(url):
+            url = url % {'version': version}
+
+        # This part is different from webassets. Try to resolve with an asset
+        # spec first, then try the base class source URL resolver.
+
+        resolved = False
         if request is not None:
             try:
-                return request.static_url(filepath)
+                url = request.static_url(url)
+                resolved = True
             except ValueError:
                 pass
-        return super(PyramidResolver, self).resolve_source_to_url(
-            filepath,
-            item
-        )
+
+        if not resolved:
+            url = super(PyramidResolver, self).resolve_source_to_url(
+                url,
+                item
+            )
+
+        if env.url_expire or (
+                env.url_expire is None and not has_placeholder(filepath)):
+            url = "%s?%s" % (url, version)
+        return url
 
     def resolve_output_to_path(self, target, bundle):
         package, filepath = self._split_asset_spec(target)

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -347,6 +347,32 @@ class TestWebAssets(unittest.TestCase):
 
         assert env.load_path == ['/foo', 'bar/', 'baz']
 
+
+    def test_webassets_source_url_versions(self):
+        import md5
+        from pyramid_webassets import get_webassets_env_from_settings
+
+        settings = {
+            'webassets.base_url': '/static',
+            'webassets.base_dir': os.getcwd(),
+            'webassets.static_view': True,
+            'webassets.cache_max_age': 3600,
+        }
+
+        env = get_webassets_env_from_settings(settings)
+        env.append_path(os.getcwd(), 'http://static.example.com')
+
+        version = md5.md5(open(__file__).read()).hexdigest()[:8]
+
+        path = 'pyramid_webassets/tests/test_webassets.py'
+        spec = 'pyramid_webassets:tests/test_webassets.py'
+        expected = 'http://static.example.com/%s?%s' % (path, version)
+
+        assert (
+            env.resolver.resolve_source_to_url(os.path.abspath(path), spec) ==
+            expected
+        )
+
     def test_auto_bool(self):
         from pyramid_webassets import get_webassets_env_from_settings
         settings = {


### PR DESCRIPTION
This ensures that assets are always served with a version when the
versioning settings are enabled, even when they are source assets
and not part of a bundle with a single output.

Might resolve #25
