### PR TITLE
Fix wrong urls built by using bundle.urls instead of bundle.build

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -324,7 +324,7 @@ def assets(request, *args, **kwargs):
     bundle = Bundle(*result, **kwargs)
     if webassets_version > (0, 9):
         with bundle.bind(env):
-            urls = bundle.build()
+            urls = bundle.urls()
     else:
         urls = bundle.urls(env=env)
 


### PR DESCRIPTION
These are related errors:

```
  File "/Users/keitheis/.virtualenvs/34/lib/python3.4/site-packages/webassets/cache.py", line 82, in walk
    raise ValueError('Cannot MD5 type %s' % type(obj))
ValueError: Cannot MD5 type <class 'method'>
```

or in browser console the url looks like

```
http://0.0.0.0:6543/%3CFileHunk%20/Users/dog/app/static/build/css/app.build/css/app.%(version)s.css.css%3E
```
