### PR TITLE
Set up tox and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+omit = pyramid_webassets/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,31 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: python setup.py test
+matrix:
+  include:
+    - python: "pypy"
+      env: TOX_ENV=pypy-webassets08
+    - python: "pypy"
+      env: TOX_ENV=pypy-webassets09
+    - python: "pypy"
+      env: TOX_ENV=pypy-webassets10
+    - python: "3.4"
+      env: TOX_ENV=py34-webassets09
+    - python: "3.4"
+      env: TOX_ENV=py34-webassets10
+    - python: "3.3"
+      env: TOX_ENV=py33-webassets09
+    - python: "3.3"
+      env: TOX_ENV=py33-webassets10
+    - python: "2.7"
+      env: TOX_ENV=py27-webassets08
+    - python: "2.7"
+      env: TOX_ENV=py27-webassets09
+    - python: "2.7"
+      env: TOX_ENV=py27-webassets10
+    - env: TOX_ENV=cover
+install:
+  - if [ x$TOX_ENV == "xcover" ]; then pip install coveralls; fi
+  - pip install tox
+script:
+  - tox -e $TOX_ENV
+after_success:
+  - if [ x$TOX_ENV == "xcover" ]; then coveralls; fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pyramid
-webassets
-zope.interface
-pytest
-pytest-cov
-mock
-six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[bdist_wheel]
+universal = 1
+
+[easy_install]
+zip_ok = False
+
+[pytest]
+norecursedirs = .git .tox *.egg

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 import os
 
-from setuptools import setup, find_packages, Command
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -20,19 +21,23 @@ extras_require = {
 }
 
 
-class PyTest(Command):
-    user_options = []
+class PyTest(TestCommand):
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
 
     def initialize_options(self):
-        pass
+        TestCommand.initialize_options(self)
+        self.tox_args = None
 
     def finalize_options(self):
-        pass
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
 
-    def run(self):
-        import subprocess
-        errno = subprocess.call('py.test')
-        raise SystemExit(errno)
+    def run_tests(self):
+        import tox
+        import shlex
+        errno = tox.cmdline(args=shlex.split(self.tox_args))
+        sys.exit(errno)
 
 setup(name='pyramid_webassets',
       version='0.8',
@@ -55,6 +60,6 @@ setup(name='pyramid_webassets',
       test_suite='pyramid_webassets',
       install_requires=requires,
       extras_require=extras_require,
-      tests_require=['pytest', 'mock'],
+      tests_require=['tox'],
       cmdclass={'test': PyTest},
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,74 @@
+[tox]
+envlist = py27-webassets08, py27-webassets09, py27-webassets10, py33-webassets09, py33-webassets10, py34-webassets09, py34-webassets10, pypy-webassets08, pypy-webassets09, pypy-webassets10, cover
+
+[testenv]
+commands = py.test {posargs}
+deps =
+    mock
+    pytest
+    PyYAML
+
+[testenv:py27-webassets08]
+basepython = python2.7
+deps = {[testenv]deps}
+    webassets>=0.8,<0.9
+
+[testenv:py27-webassets09]
+basepython = python2.7
+deps = {[testenv]deps}
+    webassets>=0.9,<0.10
+
+[testenv:py27-webassets10]
+basepython = python2.7
+deps = {[testenv]deps}
+    webassets>=0.10,<0.11
+
+[testenv:py33-webassets08]
+basepython = python3.3
+deps = {[testenv]deps}
+    webassets>=0.8,<0.9
+
+[testenv:py33-webassets09]
+basepython = python3.3
+deps = {[testenv]deps}
+    webassets>=0.9,<0.10
+
+[testenv:py33-webassets10]
+basepython = python3.3
+deps = {[testenv]deps}
+    webassets>=0.10,<0.11
+
+[testenv:py34-webassets08]
+basepython = python3.4
+deps = {[testenv]deps}
+    webassets>=0.8,<0.9
+
+[testenv:py34-webassets09]
+basepython = python3.4
+deps = {[testenv]deps}
+    webassets>=0.9,<0.10
+
+[testenv:py34-webassets10]
+basepython = python3.4
+deps = {[testenv]deps}
+    webassets>=0.10,<0.11
+
+[testenv:pypy-webassets08]
+basepython = pypy
+deps = {[testenv]deps}
+    webassets>=0.8,<0.9
+
+[testenv:pypy-webassets09]
+basepython = pypy
+deps = {[testenv]deps}
+    webassets>=0.9,<0.10
+
+[testenv:pypy-webassets10]
+basepython = pypy
+deps = {[testenv]deps}
+    webassets>=0.10,<0.11
+
+[testenv:cover]
+commands = py.test --cov pyramid_webassets {posargs}
+deps = {[testenv]deps}
+    pytest-cov


### PR DESCRIPTION
Drop requirements.txt in favor of a tox.ini and a single requirement
of tox for testing. Integrate it into setuptools and travis with
coverage reporting to coveralls.io.
