### PR TITLE
Fixing a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,6 @@ import pyramid.paster
 import webassets.script
 
 app_env = pyramid.paster.bootstrap('config.ini')
-assets_env = app_env['request'].webasset_env
+assets_env = app_env['request'].webassets_env
 webassets.script.main(['build'], assets_env)
 ```


### PR DESCRIPTION
It's `webassets_env`, not `webasset_env` :)