### PR TITLE
Resolve asset spec as path if a file exists with that path

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -47,6 +47,8 @@ class PyramidResolver(Resolver):
         self.resolver = AssetResolver(None)
 
     def _split_spec(self, item):
+        if path.isfile(item):
+            return (__name__, item)
         if ':' in item:
             package, subpath = item.split(':', 1)
             return (package, subpath)


### PR DESCRIPTION
Fixed the issue described here: https://github.com/sontek/pyramid_webassets/issues/57
For file paths on windows, the path was treated as a package due to having a colon in it.

With the fix, any asset spec will first be checked to see if it is a local file path before being treated as a package.