### PR TITLE
Change set_request_property to add_request_method

### DIFF
--- a/pyramid_webassets/__init__.py
+++ b/pyramid_webassets/__init__.py
@@ -393,6 +393,6 @@ def includeme(config):
             cache_max_age=assets_env.config['cache_max_age']
         )
 
-    config.set_request_property(get_webassets_env_from_request,
-                                'webassets_env', reify=True)
-    config.set_request_property(assets, 'webassets', reify=True)
+    config.add_request_method(get_webassets_env_from_request,
+                              'webassets_env', reify=True)
+    config.add_request_method(assets, 'webassets', reify=True)

--- a/pyramid_webassets/tests/test_webassets.py
+++ b/pyramid_webassets/tests/test_webassets.py
@@ -344,12 +344,12 @@ class TestWebAssets(unittest.TestCase):
         config = Mock()
         add_directive = Mock()
         registerUtility = Mock()
-        set_request_property = Mock()
+        add_request_method = Mock()
 
         config.registry = Mock()
         config.registry.registerUtility = registerUtility
         config.add_directive = add_directive
-        config.set_request_property = set_request_property
+        config.add_request_method = add_request_method
 
         settings = {
             'webassets.base_url': 'static',
@@ -368,7 +368,7 @@ class TestWebAssets(unittest.TestCase):
         assert add_directive.call_args_list[1][0] == expected2
         assert add_directive.call_args_list[2][0] == expected3
 
-        assert set_request_property.call_args_list[0][0] == \
+        assert add_request_method.call_args_list[0][0] == \
             (get_webassets_env_from_request, 'webassets_env')
 
     def test_get_webassets_env_from_request(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'README.md')) as fp:
 with open(os.path.join(here, 'CHANGES.txt')) as fp:
     CHANGES = fp.read()
 
-requires = ['pyramid>=1.3', 'webassets>=0.8', 'zope.interface', 'six>=1.4.1']
+requires = ['pyramid>=1.4', 'webassets>=0.8', 'zope.interface', 'six>=1.4.1']
 
 extras_require = {
     'bundles-yaml': 'PyYAML>=3.10',


### PR DESCRIPTION
pyramid.config.Configurator.set_request_property() has been deprecated
since Pyramid 1.5, and replaced with add_request_method(), which was
added in 1.4.

Pyramid 1.10 removes set_request_property, so this commit updates to use
add_request_method instead, as well as bumping the minimum required
Pyramid version to 1.4.

---

I didn't update pyramid_webassets' version number or `CHANGES.txt` since I wasn't sure exactly how you'd want to do that (such as whether you'd go to 0.10 next, or something else). I did confirm that this commit makes it work again with my app running Pyramid 1.10.

Thanks again for the quick response, I wasn't sure if this would still be maintained.